### PR TITLE
Reduce ZF request tail latency improve stability with concurrent hedging and circuit breaker

### DIFF
--- a/app/services/funnelServices/funnelServices.go
+++ b/app/services/funnelServices/funnelServices.go
@@ -1,70 +1,198 @@
 package funnelServices
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 	"strings"
+	"sync"
+
 	"wejh-go/app/apiException"
 	"wejh-go/app/utils/circuitBreaker"
 	"wejh-go/app/utils/fetch"
 	"wejh-go/config/api/funnelApi"
 )
 
+// FunnelResponse 后端统一响应格式
 type FunnelResponse struct {
 	Code int         `json:"code" binding:"required"`
 	Msg  string      `json:"message" binding:"required"`
 	Data interface{} `json:"data"`
 }
 
-func FetchHandleOfPost(form url.Values, host string, url funnelApi.FunnelApi) (interface{}, error) {
+// 对单个后端节点做一次「带 413 重试」的调用
+func singleHostRequest(host string, api funnelApi.FunnelApi, form url.Values) (FunnelResponse, error) {
 	f := fetch.Fetch{}
 	f.Init()
 
 	var rc FunnelResponse
 	var res []byte
 	var err error
+
+	// 保留原来最多 5 次、413 重试的语义
 	for i := 0; i < 5; i++ {
-		res, err = f.PostForm(host+string(url), form)
+		res, err = f.PostForm(host+string(api), form)
 		if err != nil {
-			err = apiException.RequestError
-			break
+			return FunnelResponse{}, apiException.RequestError
 		}
 		if err = json.Unmarshal(res, &rc); err != nil {
-			err = apiException.RequestError
-			break
+			return FunnelResponse{}, apiException.RequestError
 		}
 		if rc.Code != 413 {
 			break
 		}
 	}
 
+	return rc, nil
+}
+
+// FetchHandleOfPost：
+// - 非 ZF 接口：单节点调用（保留原逻辑）
+// - ZF 接口：并发对冲到所有当前可用节点 + 简单熔断 / 恢复
+func FetchHandleOfPost(form url.Values, host string, api funnelApi.FunnelApi) (interface{}, error) {
 	loginType := funnelApi.LoginType(form.Get("type"))
-	zfFlag := strings.Contains(string(url), "zf")
-	if err != nil {
-		if zfFlag {
-			circuitBreaker.CB.Fail(host, loginType)
+	// 「是否 ZF 接口」用原来的约定：URL 中包含 "zf"
+	zfFlag := strings.Contains(string(api), "zf")
+
+	// 非 ZF 接口：保持原来的串行逻辑
+	if !zfFlag {
+		rc, err := singleHostRequest(host, api, form)
+		if err != nil {
+			// 原逻辑：对调用异常统一视为 ServerError
+			return nil, apiException.ServerError
 		}
-		return nil, apiException.ServerError
+
+		switch rc.Code {
+		case 200:
+			return rc.Data, nil
+		case 413:
+			return nil, apiException.ServerError
+		case 412:
+			return nil, apiException.NoThatPasswordOrWrong
+		case 416:
+			return nil, apiException.OAuthNotUpdate
+		default:
+			return nil, apiException.ServerError
+		}
 	}
 
-	if zfFlag {
-		if rc.Code == 200 || rc.Code == 412 || rc.Code == 416 {
-			circuitBreaker.CB.Success(host, loginType)
-		} else {
-			circuitBreaker.CB.Fail(host, loginType)
+	// 拿出当前健康的节点集合
+	hosts := circuitBreaker.CB.LB.List(loginType)
+
+	// 调用方通过 GetApi 传进来的 host 优先级最高，把它挪到列表最前面
+	if host != "" {
+		found := false
+		for _, h := range hosts {
+			if h == host {
+				found = true
+				break
+			}
+		}
+		if !found {
+			hosts = append([]string{host}, hosts...)
 		}
 	}
 
-	switch rc.Code {
-	case 200:
-		return rc.Data, nil
-	case 413:
-		return nil, apiException.ServerError
-	case 412:
-		return nil, apiException.NoThatPasswordOrWrong
-	case 416:
-		return nil, apiException.OAuthNotUpdate
-	default:
-		return nil, apiException.ServerError
+	if len(hosts) == 0 {
+		// 所有节点都已熔断
+		return nil, apiException.NoApiAvailable
 	}
+
+	type result struct {
+		host string
+		rc   FunnelResponse
+		err  error
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	resultCh := make(chan result, len(hosts))
+	var wg sync.WaitGroup
+
+	// 并发对冲
+	for _, h := range hosts {
+		h := h
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			// 如果已经有其他节点成功了，尽量避免无意义请求
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			rc, err := singleHostRequest(h, api, form)
+
+			select {
+			case resultCh <- result{host: h, rc: rc, err: err}:
+			case <-ctx.Done():
+				// 上层已经有结果了，丢弃即可
+			}
+		}()
+	}
+
+	// 等所有协程结束后关闭通道
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	var firstErr error
+
+	// 竞争结果：
+	// - 第一个 200 直接返回数据，并标记该节点 Success
+	// - 第一个 412 / 416 属于用户态错误，也直接返回，不再等其它节点
+	// - 413 视为该节点过载/异常，Fail 一次，继续等待其它节点
+	for r := range resultCh {
+		if r.err != nil {
+			// 网络 / 解析错误：认为节点异常
+			circuitBreaker.CB.Fail(r.host, loginType)
+			if firstErr == nil {
+				firstErr = r.err
+			}
+			continue
+		}
+
+		switch r.rc.Code {
+		case 200:
+			// 节点健康
+			circuitBreaker.CB.Success(r.host, loginType)
+			cancel()
+			return r.rc.Data, nil
+
+		case 412:
+			// 密码错误：业务错误，节点本身是健康的
+			circuitBreaker.CB.Success(r.host, loginType)
+			cancel()
+			return nil, apiException.NoThatPasswordOrWrong
+
+		case 416:
+			// OAuth 未更新：同样是业务错误，节点健康
+			circuitBreaker.CB.Success(r.host, loginType)
+			cancel()
+			return nil, apiException.OAuthNotUpdate
+
+		case 413:
+			// 统一视为该节点过载，触发熔断统计，继续等其它节点
+			circuitBreaker.CB.Fail(r.host, loginType)
+			if firstErr == nil {
+				firstErr = apiException.ServerError
+			}
+
+		default:
+			// 其它错误码也视作节点异常
+			circuitBreaker.CB.Fail(r.host, loginType)
+			if firstErr == nil {
+				firstErr = apiException.ServerError
+			}
+		}
+	}
+
+	if firstErr == nil {
+		firstErr = apiException.ServerError
+	}
+	return nil, firstErr
 }

--- a/app/services/funnelServices/funnelServices.go
+++ b/app/services/funnelServices/funnelServices.go
@@ -106,7 +106,10 @@ func FetchHandleOfPost(form url.Values, host string, api funnelApi.FunnelApi) (i
 	}
 
 	// 拿出当前健康的节点集合
-	hosts := circuitBreaker.CB.LB.List(loginType)
+	hosts, err := circuitBreaker.CB.LB.List(loginType)
+	if err != nil {
+		return nil, err
+	}
 
 	// 调用方通过 GetApi 传进来的 host 优先级最高，把它挪到列表最前面
 	if host != "" {

--- a/app/utils/circuitBreaker/loadbalance.go
+++ b/app/utils/circuitBreaker/loadbalance.go
@@ -3,10 +3,9 @@ package circuitBreaker
 import (
 	"sync"
 
+	"github.com/bytedance/gopkg/lang/fastrand"
 	"wejh-go/app/apiException"
 	"wejh-go/config/api/funnelApi"
-
-	"github.com/bytedance/gopkg/lang/fastrand"
 )
 
 type LoadBalanceType int
@@ -27,6 +26,7 @@ func (lb *LoadBalance) Pick(zfFlag, oauthFlag bool) (string, funnelApi.LoginType
 	zfAvailable := zfFlag && lb.zfLB.isAvailable()
 
 	if oauthAvailable && zfAvailable {
+		// 双池都可用时，随机选择其一
 		if fastrand.Intn(100) > 50 {
 			return lb.oauthLB.Pick(), funnelApi.Oauth, nil
 		}
@@ -90,12 +90,13 @@ type loadBalance interface {
 
 type randomLB struct {
 	sync.Mutex
-	Api  []string
-	Size int
+	Api []string
 }
 
 func newRandomLB(apis []string) loadBalance {
-	return &randomLB{Api: apis, Size: len(apis)}
+	return &randomLB{
+		Api: apis,
+	}
 }
 
 func (b *randomLB) LoadBalance() LoadBalanceType {
@@ -107,13 +108,14 @@ func (b *randomLB) Pick() string {
 	b.Lock()
 	defer b.Unlock()
 
-	if b.Size == 0 {
+	size := len(b.Api)
+	if size == 0 {
 		return ""
 	}
-	if b.Size == 1 {
+	if size == 1 {
 		return b.Api[0]
 	}
-	return b.Api[fastrand.Intn(b.Size)]
+	return b.Api[fastrand.Intn(size)]
 }
 
 // list：返回当前后端列表的拷贝，供并发对冲使用
@@ -121,10 +123,11 @@ func (b *randomLB) list() []string {
 	b.Lock()
 	defer b.Unlock()
 
-	if b.Size == 0 {
+	size := len(b.Api)
+	if size == 0 {
 		return nil
 	}
-	out := make([]string, b.Size)
+	out := make([]string, size)
 	copy(out, b.Api)
 	return out
 }
@@ -132,14 +135,13 @@ func (b *randomLB) list() []string {
 func (b *randomLB) ReBalance(apis []string) {
 	b.Lock()
 	defer b.Unlock()
-	b.Api, b.Size = apis, len(apis)
+	b.Api = apis
 }
 
 func (b *randomLB) Add(api ...string) {
 	b.Lock()
 	defer b.Unlock()
 	b.Api = append(b.Api, api...)
-	b.Size = len(b.Api)
 }
 
 func (b *randomLB) Remove(api string) {
@@ -152,11 +154,10 @@ func (b *randomLB) Remove(api string) {
 			break
 		}
 	}
-	b.Size = len(b.Api)
 }
 
 func (b *randomLB) isAvailable() bool {
 	b.Lock()
 	defer b.Unlock()
-	return b.Size != 0
+	return len(b.Api) != 0
 }

--- a/app/utils/circuitBreaker/loadbalance.go
+++ b/app/utils/circuitBreaker/loadbalance.go
@@ -6,6 +6,7 @@ import (
 	"github.com/bytedance/gopkg/lang/fastrand"
 	"wejh-go/app/apiException"
 	"wejh-go/config/api/funnelApi"
+	"wejh-go/config/logger"
 )
 
 type LoadBalanceType int
@@ -45,19 +46,23 @@ func (lb *LoadBalance) Pick(zfFlag, oauthFlag bool) (string, funnelApi.LoginType
 
 // List 返回当前可用后端节点的快照
 // - loginType 为 Oauth：返回 OAuth 池
-// - 其它（ZF / Unknown）：统一返回 ZF 池
-func (lb *LoadBalance) List(loginType funnelApi.LoginType) []string {
+// - loginType 为 ZF：返回 ZF 池
+// - Unknown/非法值：返回错误并记录告警日志
+func (lb *LoadBalance) List(loginType funnelApi.LoginType) ([]string, error) {
 	switch loginType {
 	case funnelApi.Oauth:
 		if lb.oauthLB == nil {
-			return nil
+			return nil, nil
 		}
-		return lb.oauthLB.list()
-	default:
+		return lb.oauthLB.list(), nil
+	case funnelApi.ZF:
 		if lb.zfLB == nil {
-			return nil
+			return nil, nil
 		}
-		return lb.zfLB.list()
+		return lb.zfLB.list(), nil
+	default:
+		logger.GetLogFunc(logger.LevelWarn)("unknown login type for load balancer list: " + string(loginType))
+		return nil, apiException.ParamError
 	}
 }
 


### PR DESCRIPTION
## 背景

目前 wejh 通过 wejh-go 调用 funnel，再由 funnel 访问正方教务（ZF / OAuth）接口。

线上已知问题包括：

1. ZF 接口延迟大且不稳定，当前逻辑为 "单条线路串行重试" ，导致接口 p99 较高；
2. 启动后所有线路状态初始化为健康，小流量时难以在时间窗口内累计足够失败次数，导致 "线路已经不稳定，但仍被当做健康线路" ；
3. 内外网 + ZF/OAuth 多条线路质量差异大，目前仅做随机负载均衡，无法充分利用延迟更优的线路；
4. 夜间仅外网 ZF 可用，其它线路在固定时间段集体失效，断路阈值固定为 50，窗口期较长；
5. 可观测性较差，无法直观区分请求实际走了哪条线路，排查超时问题成本较高。

在现阶段的实际运行环境中：

- wejh-go 所在机器的 IP 已加入 ZF 白名单；
- 实际 QPM 极低，对 ZF 端的额外请求负载非常有限。

在这样的前提下，采用 "无脑并发对冲" 的策略，可以用较小的代价大幅降低尾延迟并提高成功率。

---

## 效果预测

经过模拟分析，随着并发量的提升，接口的所有指标都有极为显著的改善。因此，此方案也能大幅压缩 平均、p95、p99 延迟并提升请求的成功率：

<img width="3085" height="1646" alt="image" src="https://github.com/user-attachments/assets/77dbaa77-d78a-40c5-8a40-946b1df231ee" />

*（橙色为WeJH-Go的原逻辑，绿色为 SWRR 负载均衡 + 2 并发对冲，蓝色为本方案实现的全量对冲）*

---

## 本 PR 的主要改动

### 1. funnel 侧（ `app/services/funnelServices/funnelServices.go`）：引入 ZF 接口的并发对冲

使得 ZF 场景下的调用变为并发请求对冲，在小 QPM 前提下，可以显著压缩 p99 延迟并提升成功率。

### 2. circuitBreaker 侧（`app/utils/circuitBreaker/loadbalance.go`）：暴露可用节点列表

---

## 设计思路简述

1. **面向现有问题而不是推倒重来：**   
   在不重构整体负载均衡架构、不引入额外微服务框架和云原生组件的前提下，先解决影响用户体验的 ZF 接口 p99 延迟问题。

2. **充分利用现有熔断与健康检测：**   
   当前项目已经有 `circuitBreaker` 模块和定期健康检查任务，本次改动不重复造轮子，只是让 "对冲请求" 也参与到失败/成功统计中，从而推动线路熔断与恢复。
  由于全量并发对冲的特殊性，因此不需要负载均衡的机制。

3. **利用白名单 + 小 QPM 的现实条件：**   
   相比复杂的「智能路由 + 动态权重」，当前阶段在 wejh-go 侧做并发对冲，能以更少的工程复杂度获取更明显的收益，对 ZF 端压力也可接受。

4. **为后续迭代保留空间：**   
   新增的 `LoadBalance.List` 与对冲逻辑都是中立的：
   - 未来可以在 LB 层引入权重、Redis 持久化、时间段配置；
   - 也可以把 LB 的实现迁移到其他框架，而保持 funnel 对 `List` / `Pick` 的依赖不变。

---

## 影响

- **对调用方兼容：** 
  - `FetchHandleOfPost` 函数签名和返回语义保持不变；
  - 非 ZF 接口仍旧走单节点逻辑，不受影响；
  - controller / service 层无需改动。

- **对 ZF 服务端的影响：** 
  - 单次请求可能会并发打向多条 ZF 线路，使得本服务流向正方服务器的流量增加；
  - 在当前 QPM 较低且 IP 已在 ZF 白名单内的前提下，此方案具有可行性；
  - 若未来流量显著增长，可限制参与对冲的线路数量，或按权重裁剪候选列表。

- **对熔断和健康检测的影响：** 
  - 各线路的失败/成功统计更加充分，熔断判断更敏感；
  - 小流量场景下，即使不能快速熔断，用户也能通过对冲获得更高的成功率（特定线路的失败对用户总体无感）。

---

## 小结

本 PR 集中解决了 ZF 接口高 p99 延迟和不稳定的问题，通过简单有效的 **全量并发对冲** 策略大幅提升了用户侧体验。

请审查并给出进一步建议 🙌